### PR TITLE
fix: weird layout border on large screen

### DIFF
--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -8,7 +8,7 @@ const Footer = () => {
   const { t } = useTranslation();
 
   return (
-    <Container background="bg-washed py-12">
+    <Container background="bg-washed py-12 border-t">
       <div className="flex w-full flex-col gap-6 text-sm md:flex-row md:justify-between md:gap-0">
         <div className="flex flex-row gap-4">
           {/* LOGO */}

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -100,8 +100,8 @@ const Header: FunctionComponent<HeaderProps> = ({ stateSelector }) => {
   ];
 
   return (
-    <div className="fixed top-0 left-0 z-30 w-full">
-      <Container background="bg-white" className="flex items-center gap-4 border-b py-[11px]">
+    <div className="fixed top-0 left-0 z-30 w-full border-b">
+      <Container background="bg-white" className="flex items-center gap-4 py-[11px]">
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-4">
             <Link href="/">

--- a/data-catalogue/show.tsx
+++ b/data-catalogue/show.tsx
@@ -592,7 +592,7 @@ const CatalogueShow: FunctionComponent<CatalogueShowProps> = ({
         <Section
           title={t("catalogue.code")}
           description={t("catalogue.code_desc")}
-          className="mx-auto w-full border-b py-12"
+          className="mx-auto w-full py-12"
         >
           <CatalogueCode type={dataset.type} url={urls?.parquet || urls[Object.keys(urls)[0]]} />
         </Section>


### PR DESCRIPTION
Probably abit hard to see, but the border for header and footer is constrained to the max width and appears weird in large screens. After fixing the border should be full-sized relative to screen.

Header:
<img width="1576" alt="Screenshot 2023-02-01 at 11 03 20 PM" src="https://user-images.githubusercontent.com/101852870/216083559-1384f8ed-c67b-41d6-9372-65474609fef3.png">
<img width="201" alt="Screenshot 2023-02-01 at 11 20 20 PM" src="https://user-images.githubusercontent.com/101852870/216084130-88fd974a-a0d4-431f-9c72-291dfc7af15f.png">
<img width="108" alt="Screenshot 2023-02-01 at 11 20 25 PM" src="https://user-images.githubusercontent.com/101852870/216084135-b777ceff-bb4f-40c7-a24d-268373b2d3a2.png">

Footer:
<img width="1576" alt="Screenshot 2023-02-01 at 11 03 32 PM" src="https://user-images.githubusercontent.com/101852870/216083589-37c34d1f-80eb-4c59-9cc8-4f635e54d5c4.png">
